### PR TITLE
Use environment in job

### DIFF
--- a/.github/workflows/deploy-to-surge.yml
+++ b/.github/workflows/deploy-to-surge.yml
@@ -48,6 +48,7 @@ jobs:
   surge-deploy:
     name: Deploy to Surge
     needs: build
+    environment: surge-deploy
     runs-on: ubuntu-latest
 
     if: github.event_name == 'push'


### PR DESCRIPTION
- Addresses surge deployment error.

## Changes

* Use github environment for deployment to surge.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
